### PR TITLE
Elixir 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Provides a clean, composable named functions. Also doubles as an aliasing device
 ```elixir
 defmodule Contrived do
   use Quark.Pointfree
-  defx sum_plus_one, do: Enum.sum |> fn x -> x + 1 end.()
+  defx sum_plus_one, do: Enum.sum() |> fn x -> x + 1 end.()
 end
 
 Contrived.sum_plus_one([1,2,3])
@@ -154,8 +154,10 @@ Contrived.sum_plus_one([1,2,3])
 
 ## Compose
 Compose functions to do convenient partial applications.
-Versions for composing left-to-right and right-to-left are provided, but the
-operator `<|>` is done "the math way" (right-to-left).
+Versions for composing left-to-right and right-to-left are provided
+
+The operator `<|>` is done "the math way" (right-to-left).
+The operator `<~>` is done "the flow way" (left-to-right).
 
 Versions on lists also available.
 
@@ -182,7 +184,7 @@ x200.(5)
 #=> 1000
 
 add_one = &(&1 + 1)
-piped = fn x -> x |> Enum.sum |> add_one.() end
+piped = fn x -> x |> Enum.sum() |> add_one.() end
 composed = (&Enum.sum/1) <~> add_one
 piped.([1,2,3]) == composed.([1,2,3])
 #=> true
@@ -201,10 +203,10 @@ We've aliased the names at the top-level (`Quark`), so you can use `const`
 rather than having to remember what `k` means.
 
 ```elixir
- 1 |> i
+ 1 |> i()
 #=> 1
 
-"identity combinator" |> i
+"identity combinator" |> i()
 #=> "identity combinator"
 
 Enum.reduce([1,2,3], [42], &k/2)
@@ -258,6 +260,6 @@ This works with any ordered collection via the `Quark.Sequence` protocol.
 succ 10
 #=> 11
 
-42 |> origin |> pred |> pred
+42 |> origin() |> pred() |> pred()
 #=> -2
 ```

--- a/lib/quark/compose.ex
+++ b/lib/quark/compose.ex
@@ -27,7 +27,7 @@ defmodule Quark.Compose do
   ## Examples
 
       iex> sum_plus_one = compose(&(&1 + 1), &Enum.sum/1)
-      iex> [1,2,3] |> sum_plus_one.()
+      ...> [1, 2, 3] |> sum_plus_one.()
       7
 
   """
@@ -59,13 +59,13 @@ defmodule Quark.Compose do
   ## Examples
 
       iex> sum_plus_one = fn x -> x + 1 end <|> &Enum.sum/1
-      iex> sum_plus_one.([1,2,3])
+      ...> sum_plus_one.([1,2,3])
       7
 
-      iex> add_one = &(&1 + 1)
-      iex> piped = [1,2,3] |> Enum.sum |> add_one.()
-      iex> composed = [1,2,3] |> ((add_one <|> &Enum.sum/1)).()
-      iex> piped == composed
+      iex> add_one  = &(&1 + 1)
+      ...> piped    = [1, 2, 3] |> Enum.sum() |> add_one.()
+      ...> composed = [1, 2, 3] |> ((add_one <|> &Enum.sum/1)).()
+      ...> piped == composed
       true
 
   """
@@ -77,13 +77,13 @@ defmodule Quark.Compose do
 
   ## Examples
 
-      iex> sum_plus_one = compose_forward(&(Enum.sum(&1)), &(&1 + 1))
-      iex> [1,2,3] |> sum_plus_one.()
+      iex> sum_plus_one = compose_forward(&Enum.sum/1, &(&1 + 1))
+      ...> [1, 2, 3] |> sum_plus_one.()
       7
 
   """
   @spec compose_forward(fun, fun) :: fun
-  defpartial compose_forward(f,g) do
+  defpartial compose_forward(f, g) do
     fn x ->
       x
       |> curry(f).()
@@ -97,17 +97,17 @@ defmodule Quark.Compose do
   ## Examples
 
       iex> sum_plus_one = (&Enum.sum/1) <~> fn x -> x + 1 end
-      iex> sum_plus_one.([1,2,3])
+      ...> sum_plus_one.([1, 2, 3])
       7
 
       iex> x200 = (&(&1 * 2)) <~> (&(&1 * 10)) <~> (&(&1 * 10))
-      iex> x200.(5)
+      ...> x200.(5)
       1000
 
-      iex> add_one = &(&1 + 1)
-      iex> piped = [1,2,3] |> Enum.sum |> add_one.()
-      iex> composed = [1,2,3] |> ((&Enum.sum/1) <~> add_one).()
-      iex> piped == composed
+      iex> add_one  = &(&1 + 1)
+      ...> piped    = [1, 2, 3] |> Enum.sum() |> add_one.()
+      ...> composed = [1, 2, 3] |> ((&Enum.sum/1) <~> add_one).()
+      ...> piped == composed
       true
 
   """
@@ -122,12 +122,29 @@ defmodule Quark.Compose do
   ## Examples
 
       iex> sum_plus_one = compose_list_forward([&Enum.sum/1, &(&1 + 1)])
-      ...> [1,2,3] |> sum_plus_one.()
+      ...> sum_plus_one.([1, 2, 3])
       7
 
   """
   @spec compose_list_forward([fun]) :: fun
   defpartial compose_list_forward(func_list) do
-    func_list |> Enum.reduce(&id/1, &compose/2)
+    List.foldl(func_list, &id/1, &compose/2)
+  end
+
+  @doc ~S"""
+  Compose functions, from the head of the list of functions. The is the reverse
+  order versus what one would normally expect (left-to-right rather than
+  right-to-left).
+
+  ## Examples
+
+  iex> sum_plus_one = compose_list([&(&1 + 1), &Enum.sum/1])
+  ...> sum_plus_one.([1, 2, 3])
+  7
+
+  """
+  @spec compose_list([fun]) :: fun
+  defpartial compose_list(func_list) do
+    List.foldr(func_list, &id/1, &compose/2)
   end
 end

--- a/lib/quark/fixed_point.ex
+++ b/lib/quark/fixed_point.ex
@@ -74,7 +74,7 @@ defmodule Quark.FixedPoint do
 
   """
   @spec turing(fun) :: fun
-  defpartial turing(fun), do: turing_inner.(turing_inner).(fun)
+  defpartial turing(fun), do: turing_inner().(turing_inner()).(fun)
 
   defpartialp turing_inner(x, y) do
     cx = curry(x)
@@ -101,5 +101,5 @@ defmodule Quark.FixedPoint do
 
   """
   @spec z(fun, any) :: fun
-  defpartial z(g, v), do: g.(z.(g)).(v)
+  defpartial z(g, v), do: g.(z(g)).(v)
 end

--- a/lib/quark/sequence.ex
+++ b/lib/quark/sequence.ex
@@ -58,7 +58,7 @@ defimpl Quark.Sequence, for: Integer do
       0
 
   """
-  def origin(num), do: 0
+  def origin(_num), do: 0
 
   @doc ~S"""
   ## Examples

--- a/lib/quark/sequence.ex
+++ b/lib/quark/sequence.ex
@@ -25,7 +25,7 @@ defprotocol Quark.Sequence do
       iex> succ(1)
       #=> 2
 
-      iex> 10 |> origin |> succ |> succ
+      iex> 10 |> origin() |> succ() |> succ()
       #=> 2
 
   """
@@ -42,7 +42,7 @@ defprotocol Quark.Sequence do
       pred(10)
       #=> 9
 
-      42 |> origin |> pred |> pred
+      42 |> origin() |> pred() |> pred()
       #=> -2
 
   """
@@ -65,7 +65,7 @@ defimpl Quark.Sequence, for: Integer do
       iex> succ(1)
       2
 
-      iex> 10 |> origin |> succ |> succ
+      iex> 10 |> origin() |> succ() |> succ()
       2
 
   """
@@ -77,7 +77,7 @@ defimpl Quark.Sequence, for: Integer do
       iex> pred(10)
       9
 
-      iex> 42 |> origin |> pred |> pred
+      iex> 42 |> origin() |> pred() |> pred()
       -2
 
   """

--- a/lib/quark/ski.ex
+++ b/lib/quark/ski.ex
@@ -52,7 +52,7 @@ defmodule Quark.SKI do
 
   """
   @spec k(any, any) :: any
-  defpartial k(x, y), do: x
+  defpartial k(x, _y), do: x
 
   defdelegate constant(a, b), to: __MODULE__, as: :k
   defdelegate first(a, b),    to: __MODULE__, as: :k

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Quark.Mixfile do
       name: "Quark",
 
       description: "Common combinators for Elixir",
-      version: "2.2.1",
+      version: "2.3.0",
       elixir:  "~> 1.4",
 
       package: [
@@ -19,7 +19,13 @@ defmodule Quark.Mixfile do
       source_url:   "https://github.com/expede/quark",
       homepage_url: "https://github.com/expede/quark",
 
-      aliases: ["quality": ["test", "credo --strict"]],
+      aliases: [
+        "quality": [
+          "test",
+          "credo --strict",
+          "dialyzer"
+        ]
+      ],
 
       deps: [
         {:credo,    "~> 0.8",  only: [:dev, :test]},

--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,8 @@ defmodule Quark.Mixfile do
       name: "Quark",
 
       description: "Common combinators for Elixir",
-      version: "2.2.0",
-      elixir:  "~> 1.3",
+      version: "2.2.1",
+      elixir:  "~> 1.4",
 
       package: [
         maintainers: ["Brooklyn Zelenka"],
@@ -22,11 +22,11 @@ defmodule Quark.Mixfile do
       aliases: ["quality": ["test", "credo --strict"]],
 
       deps: [
-        {:credo,    "~> 0.4.14",  only: [:dev, :test]},
+        {:credo,    "~> 0.8",  only: [:dev, :test]},
 
-        {:dialyxir, "~> 0.3",  only: :dev},
-        {:earmark,  "~> 1.0",  only: :dev},
-        {:ex_doc,   "~> 0.13", only: :dev},
+        {:dialyxir, "~> 0.5",  only: :dev},
+        {:earmark,  "~> 1.2",  only: :dev},
+        {:ex_doc,   "~> 0.16", only: :dev},
 
         {:inch_ex,  "~> 0.5",  only: [:dev, :docs, :test]}
       ],

--- a/mix.exs
+++ b/mix.exs
@@ -22,8 +22,7 @@ defmodule Quark.Mixfile do
       aliases: [
         "quality": [
           "test",
-          "credo --strict",
-          "dialyzer"
+          "credo --strict"
         ]
       ],
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
-%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [], [], "hexpm"},
-  "credo": {:hex, :credo, "0.4.14", "594a965ae2224997fae9e705e881983911a052c701b05bd3bcf89af44b5f6b45", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.8.1", "137efcc99b4bc507c958ba9b5dff70149e971250813cbe7d4537ec7e36997402", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], [], "hexpm"},
+%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [], [], "hexpm"},
   "credo": {:hex, :credo, "0.4.14", "594a965ae2224997fae9e705e881983911a052c701b05bd3bcf89af44b5f6b45", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
-  "dialyxir": {:hex, :dialyxir, "0.3.5", "eaba092549e044c76f83165978979f60110dc58dd5b92fd952bf2312f64e9b14", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.13.1", "658dbfc8cc5b0fac192f0f3254efe66ee6294200804a291549e0aeb052053bba", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "inch_ex": {:hex, :inch_ex, "0.5.3", "39f11e96181ab7edc9c508a836b33b5d9a8ec0859f56886852db3d5708889ae7", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm"}}
+  "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"}}

--- a/test/quark/curry_test.exs
+++ b/test/quark/curry_test.exs
@@ -6,20 +6,20 @@ defmodule Quark.CurryTest do
   defcurryp minus(a, b), do: a - b
 
   test "applies in sequence" do
-    assert div.(10).(5) == 2
+    assert div().(10).(5) == 2
   end
 
   test "curried functions can partially apply" do
-    div10 = div.(10)
+    div10 = div().(10)
     assert div10.(2) == 5
   end
 
   test "private functions apply in sequence" do
-    assert minus.(10).(2) == 8
+    assert minus().(10).(2) == 8
   end
 
   test "private curried functions can partially apply" do
-    below10 = minus.(10)
+    below10 = minus().(10)
     assert below10.(9) == 1
   end
 end

--- a/test/quark/partial_test.exs
+++ b/test/quark/partial_test.exs
@@ -9,7 +9,7 @@ defmodule Quark.PartialTest do
 
   defpartial minus(a, b, c), do: a - b - c
   test "creates fully-curried functions" do
-    assert minus.(10).(2).(1) == 7
+    assert minus().(10).(2).(1) == 7
   end
 
   test "can partially apply functions" do
@@ -22,7 +22,7 @@ defmodule Quark.PartialTest do
 
   defpartialp minusp(a, b, c), do: a - b - c
   test "creates fully-curried private functions" do
-    assert minusp.(10).(2).(1) == 7
+    assert minusp().(10).(2).(1) == 7
   end
 
   test "can partially apply private functions" do


### PR DESCRIPTION
- Fix compiler warnings about missing parens (from Elixir 1.4)
- Add `compose_list/1`

#11 